### PR TITLE
Mark TEP006 as completed

### DIFF
--- a/TEP006_configuration_tags.rst
+++ b/TEP006_configuration_tags.rst
@@ -4,17 +4,24 @@ TEP006: Configuration parsing improvement
 Status
 ======
 
-**Discussion**
+**Completed**
 
 Responsible
 ===========
 
 @wkerzendorf
+@ftsamis
 
 Branches and Pull requests
 ==========================
+tardis-sn/tardis#623
+tardis-sn/tardis#632
+tardis-sn/tardis#635
+tardis-sn/tardis#636
+tardis-sn/tardis#638
+tardis-sn/tardis#645
 
-N/A
+Final PR: tardis-sn/tardis#652
 
 
 Description


### PR DESCRIPTION
Since https://github.com/tardis-sn/tardis/pull/652 is now merged, I believe it's the time to mark TEP006 as Completed.